### PR TITLE
Remote incorrect protocol in front of example source url

### DIFF
--- a/example/aurora.tf
+++ b/example/aurora.tf
@@ -13,7 +13,7 @@ variable "cluster_state_bucket" {
 }
 
 module "aurora_db" {
-  source = "https://github.com/ministryofjustice/cloud-platform-terraform-rds-aurora?ref=1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-aurora?ref=1.1"
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket
   team_name              = "example-team"


### PR DESCRIPTION
Without this change, the following error is presented:
```
"https://github.com/ministryofjustice/cloud-platform-terraform-rds-aurora?ref=1.1":
error downloading
'https://github.com/ministryofjustice/cloud-platform-terraform-rds-aurora?ref=1.1':
no source URL was returned
```