### PR TITLE
Remove `storage_encrypted` variable, rds_name variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,7 +43,7 @@ resource "random_id" "id" {
 }
 
 locals {
-  identifier       = var.rds_name != "" ? var.rds_name : "cloud-platform-${random_id.id.hex}"
+  identifier       = "cloud-platform-${random_id.id.hex}"
   db_name          = var.db_name != "" ? var.db_name : "db${random_id.id.hex}"
   port             = var.port == "" ? var.engine == "aurora-postgresql" ? "5432" : "3306" : var.port
   backtrack_window = (var.engine == "aurora-mysql" || var.engine == "aurora") && var.engine_mode != "serverless" ? var.backtrack_window : 0
@@ -124,7 +124,7 @@ resource "aws_rds_cluster" "aurora" {
   db_subnet_group_name            = aws_db_subnet_group.db_subnet.name
   vpc_security_group_ids          = [aws_security_group.rds-sg.id]
   snapshot_identifier             = var.snapshot_identifier
-  storage_encrypted               = var.storage_encrypted
+  storage_encrypted               = true
   apply_immediately               = var.apply_immediately
   allow_major_version_upgrade     = var.allow_major_version_upgrade
   db_cluster_parameter_group_name = var.db_cluster_parameter_group_name

--- a/variables.tf
+++ b/variables.tf
@@ -36,12 +36,6 @@ variable "publicly_accessible" {
   default     = false
 }
 
-variable "storage_encrypted" {
-  description = "Specifies whether the underlying storage layer should be encrypted"
-  type        = bool
-  default     = true
-}
-
 variable "apply_immediately" {
   description = "Determines whether or not any DB modifications are applied immediately, or during the maintenance window"
   type        = bool
@@ -56,12 +50,6 @@ variable "db_cluster_parameter_group_name" {
 
 variable "db_name" {
   description = "The name of the database to be created on the instance (if empty, it will be the generated random identifier)"
-  default     = ""
-  type        = string
-}
-
-variable "rds_name" {
-  description = "Optional name of the RDS cluster. Changing the name will re-create the RDS"
   default     = ""
   type        = string
 }


### PR DESCRIPTION
This PR removes the `storage_encrypted` and `rds_name` variables.

This is because we don't want teams to turn off encryption; and we prefer RDS names that are randomly generated.