### PR TITLE
Remove access keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_db_subnet_group.db_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_subnet_group) | resource |
-| [aws_iam_access_key.user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_access_key) | resource |
 | [aws_iam_policy.irsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_user.user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
-| [aws_iam_user_policy.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy) | resource |
 | [aws_kms_alias.alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_rds_cluster.aurora](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster) | resource |
@@ -72,7 +69,6 @@ No modules.
 | [random_string.username](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.irsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 | [aws_subnets.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
@@ -125,7 +121,6 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_access_key_id"></a> [access\_key\_id](#output\_access\_key\_id) | Access key id for RDS IAM user |
 | <a name="output_database_name"></a> [database\_name](#output\_database\_name) | Name of the database |
 | <a name="output_database_password"></a> [database\_password](#output\_database\_password) | Database Password |
 | <a name="output_database_username"></a> [database\_username](#output\_database\_username) | Database Username |
@@ -136,7 +131,6 @@ No modules.
 | <a name="output_rds_cluster_reader_endpoint"></a> [rds\_cluster\_reader\_endpoint](#output\_rds\_cluster\_reader\_endpoint) | A reader endpoint for the aurora DB cluster. Use the reader endpoint for read operations, such as queries |
 | <a name="output_rds_instance_endpoint"></a> [rds\_instance\_endpoint](#output\_rds\_instance\_endpoint) | An instance endpoint connecting the DB instance within an Aurora cluster |
 | <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id) | RDS Resource ID - used for performance insights (metrics) |
-| <a name="output_secret_access_key"></a> [secret\_access\_key](#output\_secret\_access\_key) | Secret key for RDS IAM user |
 <!-- END_TF_DOCS -->
 
 ## Tags

--- a/main.tf
+++ b/main.tf
@@ -188,45 +188,6 @@ resource "aws_rds_cluster_instance" "aurora_instances" {
   })
 }
 
-# Legacy long-lived credentials
-resource "aws_iam_user" "user" {
-  name = "rds-cluster-snapshots-user-${random_id.id.hex}"
-  path = "/system/rds-cluster-snapshots-user/"
-
-  tags = local.default_tags
-}
-
-resource "aws_iam_access_key" "user" {
-  user = aws_iam_user.user.name
-}
-
-data "aws_iam_policy_document" "policy" {
-  statement {
-    actions = [
-      "rds:DescribeDBClusterSnapshots",
-      "rds:DescribeDBClusters",
-      "rds:CopyDBClusterSnapshot",
-      "rds:DeleteDBClusterSnapshot",
-      "rds:DescribeDBClusterSnapshotAttributes",
-      "rds:CreateDBClusterSnapshot",
-      "rds:ModifyDBClusterSnapshotAttribute",
-      "rds:RestoreDBClusterFromSnapshot",
-    ]
-
-    resources = [
-      aws_rds_cluster.aurora.arn,
-      "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:cluster-snapshot:*",
-    ]
-  }
-
-}
-
-resource "aws_iam_user_policy" "policy" {
-  name   = "rds-cluster-snapshots-read-write"
-  policy = data.aws_iam_policy_document.policy.json
-  user   = aws_iam_user.user.name
-}
-
 # Short-lived credentials (IRSA)
 data "aws_iam_policy_document" "irsa" {
   version = "2012-10-17"

--- a/outputs.tf
+++ b/outputs.tf
@@ -44,17 +44,6 @@ output "resource_id" {
   value       = aws_rds_cluster.aurora.cluster_resource_id
 }
 
-output "access_key_id" {
-  description = "Access key id for RDS IAM user"
-  value       = join("", aws_iam_access_key.user.*.id)
-
-}
-
-output "secret_access_key" {
-  description = "Secret key for RDS IAM user"
-  value       = join("", aws_iam_access_key.user.*.secret)
-}
-
 output "irsa_policy_arn" {
   value = aws_iam_policy.irsa.arn
 }


### PR DESCRIPTION
Related to [Deprecating long-lived credentials for modules](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/deprecating-long-lived-credentials.html) and ministryofjustice/cloud-platform#4546, ministryofjustice/cloud-platform#4372.